### PR TITLE
Update ready.js

### DIFF
--- a/src/events/handlers/ready.js
+++ b/src/events/handlers/ready.js
@@ -130,7 +130,7 @@ function logWithStyle(status, message) {
 }
 
 module.exports = {
-    name: 'ready',
+    name: 'clientReady',
     once: true,
     async execute(client) {
         logWithStyle('SUCCESS', 'Bot is ready and connected to Discord!');


### PR DESCRIPTION
The 'ready' event has been renamed to 'clientReady' to distinguish it from the gateway READY event and will only emit under that name in v15.